### PR TITLE
Fix Simplified Chinese

### DIFF
--- a/lib/internal/languages.dart
+++ b/lib/internal/languages.dart
@@ -68,7 +68,7 @@ final supportedLanguages = <LanguageData>[
   // French (FR)
   LanguageData("🇫🇷", "French", "fr"),
   // Chinese (CN)
-  LanguageData("cn", "Simplified Chinese", "zh"),
+  LanguageData("🇨🇳", "Simplified Chinese", "cn"),
   // Czech (CS)
   LanguageData("🇨🇿", "Čeština", "cs"),
   // Sorani (CKB)


### PR DESCRIPTION
Because the language code is written incorrectly, Chinese cannot be enabled normally